### PR TITLE
Reinitialize simulcast layers when base SSRC changes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,14 +246,26 @@ Simulcast.prototype._maybeInitializeLayers = function(mLine) {
     }
 
     // find the base layer (we'll reuse its msid and cname).
-    var baseLayerSSRC = Object.keys(sources)[0];
+    var baseLayerSSRC;
+    // If we have stored layers the first one is the base layer, but pick it
+    // only if it's SSRC still exists in local description. If not then
+    // the layers will be reinitialized(baseline SSRCs will not match).
+    if (this.layers.length > 0 && sources[this.layers[0].ssrc]) {
+        baseLayerSSRC = this.layers[0].ssrc;
+    } else {
+        // FIXME Picking first key is ok only if there is 1 SSRC, otherwise
+        // Object keys will be sorted in ascending order. Usually this is
+        // the initialization case when there are no layers.
+        baseLayerSSRC = Object.keys(sources)[0];
+    }
     var baseLayer = sources[baseLayerSSRC];
 
     // todo(gp) handle screen sharing.
 
-    // check if base CNAME has changed and reinitialise layers.
+    // check if base CNAME or SSRC has changed and reinitialise layers.
     if (this.layers.length > 0
-        && sources[baseLayerSSRC].cname !== this.layers[0].cname) {
+        && (baseLayer.cname !== this.layers[0].cname ||
+            baseLayerSSRC !== this.layers[0].ssrc)) {
         this.layers = [];
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -249,26 +249,21 @@ Simulcast.prototype._maybeInitializeLayers = function(mLine) {
     var baseLayerSSRC;
     // If we have stored layers the first one is the base layer, but pick it
     // only if it's SSRC still exists in local description. If not then
-    // the layers will be reinitialized(baseline SSRCs will not match).
+    // the layers will be reinitialized.
     if (this.layers.length > 0 && sources[this.layers[0].ssrc]) {
         baseLayerSSRC = this.layers[0].ssrc;
     } else {
-        // FIXME Picking first key is ok only if there is 1 SSRC, otherwise
-        // Object keys will be sorted in ascending order. Usually this is
-        // the initialization case when there are no layers.
+        // Initialize new layers
+        this.layers = [];
+        // Object.keys is sorted in ascending order. It should be ok
+        // for the initialization case when 1 video SSRC is assumed.
+        baseLayerSSRC = Object.keys(sources)[0];
         // Object.keys() returns string
-        baseLayerSSRC = parseInt(Object.keys(sources)[0]);
+        baseLayerSSRC = parseInt(baseLayerSSRC);
     }
     var baseLayer = sources[baseLayerSSRC];
 
     // todo(gp) handle screen sharing.
-
-    // check if base CNAME or SSRC has changed and reinitialise layers.
-    if (this.layers.length > 0
-        && (baseLayer.cname !== this.layers[0].cname ||
-            baseLayerSSRC !== this.layers[0].ssrc)) {
-        this.layers = [];
-    }
 
     // (re)initialise layers
     if (this.layers.length < 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -256,7 +256,8 @@ Simulcast.prototype._maybeInitializeLayers = function(mLine) {
         // FIXME Picking first key is ok only if there is 1 SSRC, otherwise
         // Object keys will be sorted in ascending order. Usually this is
         // the initialization case when there are no layers.
-        baseLayerSSRC = Object.keys(sources)[0];
+        // Object.keys() returns string
+        baseLayerSSRC = parseInt(Object.keys(sources)[0]);
     }
     var baseLayer = sources[baseLayerSSRC];
 

--- a/lib/transform-utils.js
+++ b/lib/transform-utils.js
@@ -48,6 +48,7 @@ exports.writeSsrcs = function(sources, order) {
 
     // Now add the rest of the sources.
     Object.keys(sources).forEach(function (ssrc) {
+      ssrc = parseInt(ssrc); // Object.keys() returns string
       if (order.indexOf(ssrc) >= 0) {
         // Already added.
         return;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "George Politis",
     "email": "gp@jitsi.org"
   },
-  "version": "0.1.6",
+  "version": "0.1.7",
   "stability": "unstable",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes video unmute issues in Jitsi Meet on Chrome > 52 by reinitializing simulcast layers when 'cname' remains the same, but SSRC of the base layer changes. The 'msid' was not updated with the new stream.

It also fixes problem with SSRC lines of 2nd and 3rd simulcast layers being duplicated in the local description.

This is another version of PR#2 which removes the cname check. Tested and work on both current stable and 52 Chrome versions.
