### PR TITLE
Remove 'isSupported' method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -424,16 +424,6 @@ Simulcast.prototype._restoreSimulcast = function(mLine) {
 
 //region "Public" functions
 
-Simulcast.prototype.isSupported = function () {
-    return !!window.chrome;
-
-    // TODO this needs improvements. For example I doubt that Chrome in Android
-    // has simulcast support.
-    // Think about just removing this, since the user of the library is probably
-    // in a better position to know what browser it is running in and
-    // whether simulcast should be used.
-}
-
 /**
  *
  * @param desc
@@ -474,12 +464,14 @@ Simulcast.prototype.mungeRemoteDescription = function (desc) {
 
 /**
  *
+ * NOTE this method should be called only if simulcast is supported by
+ * the current browser, otherwise local SDP should not be munged.
  * @param desc
  * @returns {RTCSessionDescription}
  */
 Simulcast.prototype.mungeLocalDescription = function (desc) {
 
-    if (!validateDescription(desc) || !this.isSupported()) {
+    if (!validateDescription(desc)) {
         return desc;
     }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "George Politis",
     "email": "gp@jitsi.org"
   },
-  "version": "0.1.12",
+  "version": "0.2.0",
   "stability": "unstable",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The user of the library is in better position to decide on whether simulcast should be used or not.