### PR TITLE
Add support for simulcast in Unified plan mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -335,6 +335,21 @@ Simulcast.prototype._generateSourceData = function(mLine, primarySsrc) {
     var primarySsrcMsid = getSsrcAttribute(mLine, primarySsrc, "msid");
     var primarySsrcCname = getSsrcAttribute(mLine, primarySsrc, "cname");
 
+    // In Unified-plan mode, the a=ssrc lines with the msid attribute are not present
+    // in the answers that Chrome and Safari generate for an offer received from Jicofo.
+    // Generate these a=ssrc lines using the msid values from the a=msid line.
+    if (this.options.usesUnifiedPlan && !primarySsrcMsid) {
+        primarySsrcMsid = mLine.msid;
+        var primarySsrcs = mLine.ssrcs;
+        primarySsrcs.forEach(ssrc => {
+            mLine.ssrcs.push({
+                id: ssrc.id,
+                attribute: "msid",
+                value: primarySsrcMsid
+            });
+        });
+    }
+
     // Generate sim layers
     var simSsrcs = [];
     for (var i = 0; i < this.options.numOfLayers - 1; ++i) {
@@ -469,8 +484,9 @@ Simulcast.prototype.mungeRemoteDescription = function (desc) {
         // 5. Any subsequent re-negotiation (for example, due to a participant
         //    joining/leaving the call) will enable simulcast and this switch
         //    almost always results in a broken stream at the receiver.
-
-        assertGoogConference(mLine);
+        if (!self.options.usesUnifiedPlan) {
+            assertGoogConference(mLine);
+        }
     });
 
     return new RTCSessionDescription({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jitsi/sdp-simulcast",
   "description": "A simple npm module that enables Chrome's native simulcast",
   "author": "",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "stability": "unstable",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Make sure we add google conference flag only when the browser is using plan-b mode. 
Firefox's SDP parser throws an error.
- Chrome and Safari (in unified plan mode) do not generate the a=ssrc lines with the msid attribute when creating an answer for the remote offer from Jicofo. Construct these lines and add them to the media description when we do the SDP munging for simulcast.